### PR TITLE
Add Creative check in Silktouch detection and add budding amethyst

### DIFF
--- a/.run/Minecraft Client.run.xml
+++ b/.run/Minecraft Client.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Minecraft Client" type="Application" factoryName="Application">
+    <envs>
+      <env name="username" value="Sebiann" />
+      <env name="uuid" value="0547eaa8-9317-4667-ac4b-2a5041dcfc2d" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="net.fabricmc.devlaunchinjector.Main" />
+    <module name="qol27.main" />
+    <option name="PROGRAM_PARAMETERS" value="-XX:+AllowEnhancedClassRedefinition" />
+    <shortenClasspath name="ARGS_FILE" />
+    <option name="VM_PARAMETERS" value="-Dfabric.dli.config=$PROJECT_DIR$/.gradle/loom-cache/launch.cfg -Dfabric.dli.env=client -Dfabric.dli.main=net.fabricmc.loader.impl.launch.knot.KnotClient" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run/" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/THIS ONE - qol27 [remapJar].run.xml
+++ b/.run/THIS ONE - qol27 [remapJar].run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="THIS ONE - qol27 [remapJar]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="remapJar" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/qol27 [runClient].run.xml
+++ b/.run/qol27 [runClient].run.xml
@@ -1,6 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="qol27 [runClient]" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="--username" value="Sebiann" />
+        </map>
+      </option>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />

--- a/.run/qol27 [runClient].run.xml
+++ b/.run/qol27 [runClient].run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="qol27 [runClient]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runClient" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn_mappings=1.21.8+build.1
 loader_version=0.17.2
 kotlin_loader_version=1.13.4+kotlin.2.2.0
 # Mod Properties
-mod_version=0.3.1
+mod_version=0.3.2
 maven_group=moe.sebiann
 archives_base_name=Qol27
 # Dependencies

--- a/src/main/java/moe/sebiann/qol27/client/NoSilkDetection.kt
+++ b/src/main/java/moe/sebiann/qol27/client/NoSilkDetection.kt
@@ -15,7 +15,10 @@ object NoSilkDetection {
             val heldItem: ItemStack = player.mainHandItem
             val enchantments = heldItem.enchantments.toString()
 
-            if (Config.SilkTouch.sneakOverrides && player.isShiftKeyDown) {
+            if (player.isCreative) {
+                InteractionResult.PASS
+            }
+            else if (Config.SilkTouch.sneakOverrides && player.isShiftKeyDown) {
                 InteractionResult.PASS
             }
             // Check for Ender Chest

--- a/src/main/java/moe/sebiann/qol27/client/NoSilkDetection.kt
+++ b/src/main/java/moe/sebiann/qol27/client/NoSilkDetection.kt
@@ -29,13 +29,17 @@ object NoSilkDetection {
                     InteractionResult.FAIL
                 }
             }
-            // Check for Glass blocks (separate condition)
+            // Check for Glass blocks
             else if (isGlassBlock(block) && Config.SilkTouch.glass) {
                 if (enchantments.contains("silk_touch")) {
                     InteractionResult.PASS
                 } else {
                     InteractionResult.FAIL
                 }
+            }
+            // Check for Budding Amethyst
+            else if (block == Blocks.BUDDING_AMETHYST && Config.SilkTouch.amethyst) {
+                InteractionResult.FAIL
             }
             else {
                 // Allow normal behavior for other blocks
@@ -47,40 +51,40 @@ object NoSilkDetection {
     private fun isGlassBlock(block: Block): Boolean {
         return block == Blocks.GLASS ||
             block == Blocks.TINTED_GLASS ||
-            // Regular stained glass blocks
+            // Stained glass blocks
             block == Blocks.WHITE_STAINED_GLASS ||
+            block == Blocks.LIGHT_GRAY_STAINED_GLASS ||
+            block == Blocks.GRAY_STAINED_GLASS ||
+            block == Blocks.BLACK_STAINED_GLASS ||
+            block == Blocks.BROWN_STAINED_GLASS ||
+            block == Blocks.RED_STAINED_GLASS ||
             block == Blocks.ORANGE_STAINED_GLASS ||
-            block == Blocks.MAGENTA_STAINED_GLASS ||
-            block == Blocks.LIGHT_BLUE_STAINED_GLASS ||
             block == Blocks.YELLOW_STAINED_GLASS ||
             block == Blocks.LIME_STAINED_GLASS ||
-            block == Blocks.PINK_STAINED_GLASS ||
-            block == Blocks.GRAY_STAINED_GLASS ||
-            block == Blocks.LIGHT_GRAY_STAINED_GLASS ||
-            block == Blocks.CYAN_STAINED_GLASS ||
-            block == Blocks.PURPLE_STAINED_GLASS ||
-            block == Blocks.BLUE_STAINED_GLASS ||
-            block == Blocks.BROWN_STAINED_GLASS ||
             block == Blocks.GREEN_STAINED_GLASS ||
-            block == Blocks.RED_STAINED_GLASS ||
-            block == Blocks.BLACK_STAINED_GLASS ||
+            block == Blocks.CYAN_STAINED_GLASS ||
+            block == Blocks.LIGHT_BLUE_STAINED_GLASS ||
+            block == Blocks.BLUE_STAINED_GLASS ||
+            block == Blocks.PURPLE_STAINED_GLASS ||
+            block == Blocks.MAGENTA_STAINED_GLASS ||
+            block == Blocks.PINK_STAINED_GLASS ||
             // Glass panes
             block == Blocks.GLASS_PANE ||
             block == Blocks.WHITE_STAINED_GLASS_PANE ||
+            block == Blocks.LIGHT_GRAY_STAINED_GLASS_PANE ||
+            block == Blocks.GRAY_STAINED_GLASS_PANE ||
+            block == Blocks.BLACK_STAINED_GLASS_PANE ||
+            block == Blocks.BROWN_STAINED_GLASS_PANE ||
+            block == Blocks.RED_STAINED_GLASS_PANE ||
             block == Blocks.ORANGE_STAINED_GLASS_PANE ||
-            block == Blocks.MAGENTA_STAINED_GLASS_PANE ||
-            block == Blocks.LIGHT_BLUE_STAINED_GLASS_PANE ||
             block == Blocks.YELLOW_STAINED_GLASS_PANE ||
             block == Blocks.LIME_STAINED_GLASS_PANE ||
-            block == Blocks.PINK_STAINED_GLASS_PANE ||
-            block == Blocks.GRAY_STAINED_GLASS_PANE ||
-            block == Blocks.LIGHT_GRAY_STAINED_GLASS_PANE ||
-            block == Blocks.CYAN_STAINED_GLASS_PANE ||
-            block == Blocks.PURPLE_STAINED_GLASS_PANE ||
-            block == Blocks.BLUE_STAINED_GLASS_PANE ||
-            block == Blocks.BROWN_STAINED_GLASS_PANE ||
             block == Blocks.GREEN_STAINED_GLASS_PANE ||
-            block == Blocks.RED_STAINED_GLASS_PANE ||
-            block == Blocks.BLACK_STAINED_GLASS_PANE
+            block == Blocks.CYAN_STAINED_GLASS_PANE ||
+            block == Blocks.LIGHT_BLUE_STAINED_GLASS_PANE ||
+            block == Blocks.BLUE_STAINED_GLASS_PANE ||
+            block == Blocks.PURPLE_STAINED_GLASS_PANE ||
+            block == Blocks.MAGENTA_STAINED_GLASS_PANE ||
+            block == Blocks.PINK_STAINED_GLASS_PANE
     }
 }

--- a/src/main/java/moe/sebiann/qol27/config/Config.kt
+++ b/src/main/java/moe/sebiann/qol27/config/Config.kt
@@ -16,6 +16,8 @@ class Config {
     @SerialEntry
     var silkTouchDetectionGlass: Boolean = true
     @SerialEntry
+    var silkTouchDetectionAmethyst: Boolean = true
+    @SerialEntry
     var silkTouchSneakOverrides: Boolean = true
 
     @SerialEntry
@@ -33,6 +35,8 @@ class Config {
             get() = handler.instance().silkTouchDetectionEnderchest
         val glass: Boolean
             get() = handler.instance().silkTouchDetectionGlass
+        val amethyst: Boolean
+            get() = handler.instance().silkTouchDetectionAmethyst
         val sneakOverrides: Boolean
             get() = handler.instance().silkTouchSneakOverrides
     }
@@ -86,6 +90,12 @@ class Config {
                         name(Component.translatable("config.qol27.silk_touch.glass.name"))
                         description(OptionDescription.of(Component.translatable("config.qol27.silk_touch.glass.description")))
                         binding(handler.instance()::silkTouchDetectionGlass, true)
+                        controller(tickBox())
+                    }
+                    options.register<Boolean>("silk_touch_detection_amethyst") {
+                        name(Component.translatable("config.qol27.silk_touch.amethyst.name"))
+                        description(OptionDescription.of(Component.translatable("config.qol27.silk_touch.amethyst.description")))
+                        binding(handler.instance()::silkTouchDetectionAmethyst, true)
                         controller(tickBox())
                     }
                     options.register<Boolean>("silk_touch_sneak_overrides") {

--- a/src/main/resources/assets/qol27/lang/en_us.json
+++ b/src/main/resources/assets/qol27/lang/en_us.json
@@ -6,6 +6,8 @@
   "config.qol27.silk_touch.enderchest.description":"Blocks breaking enderchests without silk touch.",
   "config.qol27.silk_touch.glass.name":"Block Glass",
   "config.qol27.silk_touch.glass.description":"Blocks breaking glass without silk touch.",
+  "config.qol27.silk_touch.amethyst.name":"Block Budding Amethyst",
+  "config.qol27.silk_touch.amethyst.description":"Blocks breaking Budding Amethyst without sneaking.",
   "config.qol27.silk_touch.sneak_overrides.name":"Sneak Overrides it",
   "config.qol27.silk_touch.sneak_overrides.description":"Sneaking overrides the silk touch requirement.",
   "config.qol27.wood_stripping.name":"Wood Stripping",


### PR DESCRIPTION
This pull request introduces a new configuration option for Silk Touch detection on Budding Amethyst blocks and refines the handling of glass block detection logic. It also updates the mod version and adds new run configurations for development. The most important changes are grouped below:

### Silk Touch Detection Improvements

* Added support for blocking the breaking of Budding Amethyst without Silk Touch, controlled by a new config option `silkTouchDetectionAmethyst`. This includes changes to the detection logic and configuration handling in `Config.kt` and `NoSilkDetection.kt`. [[1]](diffhunk://#diff-14448c4dba4ba5e775f1ef32083862bbff72cac524e0b7724ff09ebbfb04b654R19-R20) [[2]](diffhunk://#diff-14448c4dba4ba5e775f1ef32083862bbff72cac524e0b7724ff09ebbfb04b654R38-R39) [[3]](diffhunk://#diff-14448c4dba4ba5e775f1ef32083862bbff72cac524e0b7724ff09ebbfb04b654R95-R100) [[4]](diffhunk://#diff-8db7f1094049177d3b9409ceda55ead0fdd072551efd131909b88dfe1f9c5b18L29-R43)
* Refined the glass block detection logic to include all stained glass and glass pane variants, ensuring comprehensive coverage when Silk Touch detection for glass is enabled.

### Configuration and Localization

* Added new English localization strings for the Budding Amethyst Silk Touch option in `en_us.json`.

### Mod Version Update

* Updated the mod version from `0.3.1` to `0.3.2` in `gradle.properties`.

### Development Environment

* Added new run configurations for Minecraft Client and Gradle tasks (`runClient`, `remapJar`) to the `.run/` directory for easier development and testing. (.run/Minecraft Client.run.xml [.run/Minecraft Client.run.xmlR1-R17](diffhunk://#diff-2fce040336fc8906dd58cb27c708e7f4b870bc4b4aee440d81134f3f9b95fb3cR1-R17), .run/qol27 [runClient].run.xml [.run/qol27 [runClient].run.xmlR1-R29](diffhunk://#diff-e6780b0450bb34aaf50468f5882576b658c57c4ffa699867f30d9c737a0679ecR1-R29), .run/THIS ONE - qol27 [remapJar].run.xml [.run/THIS ONE - qol27 [remapJar].run.xmlR1-R24](diffhunk://#diff-4922f8b2bd0a0b8c9e7bbf65bba22f44583d2bc35f20326d5a0e59aefa51dc3bR1-R24))